### PR TITLE
READMEにrequireの表記を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Faker::Japanese
 
  * フルネーム
 
+        require 'faker/japanese`
+
         20.times do
           name = Faker::Japanese::Name.name
           puts "#{name} (#{name.yomi})"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Faker::Japanese
 
  * フルネーム
 
-        require 'faker/japanese`
+        require "faker/japanese"
 
         20.times do
           name = Faker::Japanese::Name.name
@@ -45,6 +45,8 @@ Faker::Japanese
 
 
  * 苗字と名前
+
+        require "faker/japanese"
 
         20.times do
           first_name = Faker::Japanese::Name.first_name


### PR DESCRIPTION
## 内容（箇条書き）
『素晴らしいプロダクトに感謝しています。』
+ こうすればより良いと思うこと
READMEの使い方のコードに以下を追記するのはいかがでしょうか？
```
require 'faker/japanese`

もしくは、
//Faker::japanese::nameのみ使用する場合
require 'faker/japanese/name`

```
+ なぜそう思うのか
使い方のソースコードに`require`の記述を含めた方がユーザーが問題なく`faker-japanese`を使用できるかもしれないと思ったため。
` gem install faker-japanese`を実行後、初学者はどのように`require`したらいいのかわからない可能性があるため。
私自身、`require faker-japanese`と記述してしまいloadエラーを起こしてしまったため。

また、今後の実装次第だとは思われますが、
`require "faker/japanese/name"`
などの方法でfaker-japaneseの部分的な利用が可能だということもREADMEに記述されるのはいかがでしょうか？

## 環境

OS: mac OS Monterey 12.6.5
Ruby:3.2.2